### PR TITLE
remove save bonus from stinking cloud

### DIFF
--- a/bg2fixpack/lib/beta_core.tph
+++ b/bg2fixpack/lib/beta_core.tph
@@ -145,6 +145,10 @@ COPY_EXISTING ~spwi208.spl~ ~override~ // know alignment (arcane)
   LPF ALTER_EFFECT INT_VAR match_opcode = 139 savingthrow = BIT0 END // add save to string
   LPF ALTER_EFFECT INT_VAR match_opcode = 115 savingthrow = BIT0 END // add save to know alignment
 
+// stinking cloud description doesn't mention a saving throw modificator, but spell provides a bonus of 2
+COPY_EXISTING ~spwi213.spl~ ~override~ // stinking cloud
+  LPF ALTER_EFFECT INT_VAR savebonus = 0 END // no save bonus
+
 /////                                                  \\\\\
 ///// eff fixes                                        \\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
Stinking Cloud doesn't mention any save roll modificator in the description.
EEs [legitimized](https://baldursgate.fandom.com/wiki/Stinking_Cloud) save bonus instead.
However, from a cursory look the [pnp version](https://adnd2e.fandom.com/wiki/Stinking_Cloud) still doesn't have the mod, so original description looks correct.
Discovered [here](https://github.com/gemrb/gemrb/issues/1755#issuecomment-1336341752).